### PR TITLE
notify system of preference change

### DIFF
--- a/.my_bin/sendevent
+++ b/.my_bin/sendevent
@@ -1,0 +1,15 @@
+#!/usr/bin/env swift
+
+/**
+    Send notification
+
+    author: voldemortensen (Garth Mortensen)
+    source: https://gist.github.com/voldemortensen/d62d22ab02327dc6253d2503a9bbd679
+*/
+
+import Foundation
+
+let eventName   = CommandLine.arguments[1]
+let notifyEvent = Notification.Name(eventName)
+
+DistributedNotificationCenter.default().post(name: notifyEvent, object: nil)

--- a/on-login/set-random-color.js
+++ b/on-login/set-random-color.js
@@ -37,8 +37,8 @@ if (highlight === undefined) {
   )
 }
 
-// restart finder for these settings to take
-execSync(`killall "Finder" &> /dev/null`)
+// send notification that preferences have changed
+execSync(`./../.my_bin/sendevent AppleColorPreferencesChangedNotification`)
 
 function random(array) {
   return array[Math.floor(Math.random() * array.length)]


### PR DESCRIPTION
Unfortunately, `defaults write ...` doesn't notify OS X of preference changes.

Fortunately, notifications can be sent manually.

`sendevents` will accept any notification name and forward it to the event server for distribution. `AppleColorPreferencesChangedNotification` is the notification that `System Preferences > General > *color settings*` send when preferences are changed. Sending this notification manually removes the need to kill Finder and restart applications.