### PR TITLE
deprecate brew cask install

### DIFF
--- a/.macos
+++ b/.macos
@@ -51,7 +51,7 @@ npm install --global serve fkill-cli npm-quick-run \
 semantic-release-cli npm-check-updates
 
 echo "installing apps with brew cask"
-brew cask install alfred google-chrome firefox brave-browser bettertouchtool divvy \
+brew install --cask alfred google-chrome firefox brave-browser bettertouchtool divvy \
 bartender google-drive-file-stream itsycal visual-studio-code 1password dash \
 screenflow marshallofsound-google-play-music-player skype workflowy \
 sublime-text vlc discord obs handbrake zoomus betterzip avibrazil-rdm sip \


### PR DESCRIPTION
`brew cask install` has been deprecated, replace with `brew install --cask`  <3

https://github.com/Homebrew/discussions/discussions/340