### PR TITLE
Remove duplicated .vscode

### DIFF
--- a/.gitignore_global
+++ b/.gitignore_global
@@ -21,8 +21,6 @@ Session.vim
 *.swp
 .lvimrc
 
-# VS Code
-.vscode/
 # localhistory
 .history
 


### PR DESCRIPTION
Silly change, but `.vscode` is already ignored on line 5