### PR TITLE
Rename cask apps

### DIFF
--- a/.macos
+++ b/.macos
@@ -52,9 +52,9 @@ semantic-release-cli npm-check-updates
 
 echo "installing apps with brew cask"
 brew install --cask alfred google-chrome firefox brave-browser bettertouchtool divvy \
-bartender google-drive-file-stream itsycal visual-studio-code 1password dash \
+bartender google-drive itsycal visual-studio-code 1password dash \
 screenflow marshallofsound-google-play-music-player skype workflowy \
-sublime-text vlc discord obs handbrake zoomus betterzip avibrazil-rdm sip \
+sublime-text vlc discord obs handbrake zoom betterzip avibrazil-rdm sip \
 qlcolorcode qlmarkdown qlstephen quicklook-json webpquicklook \
 suspicious-package qlvideo spotify focus dropbox front qmoji slack
 


### PR DESCRIPTION
Removes two warnings about apps that were renamed.

- `google-drive-file-stream` will be renamed to `google-drive` - [source](https://formulae.brew.sh/cask/google-drive-file-stream)
- `zoomus` will be renamed to `zoom` - [source](https://formulae.brew.sh/cask/zoomus)
